### PR TITLE
Specify library files in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,10 @@
     "lint": "eslint .",
     "test": "ava"
   },
+  "files": [
+    "lib",
+    "index.js"
+  ],
   "dependencies": {
     "colors": "1.3.3",
     "fs-extra": "8.1.0",


### PR DESCRIPTION
This change makes the package size smaller.

**Change in package size:** From 2.2MB to 42.1kB

### Before:
```
➜  ember-unused-components git:(master) npm pack --dry-run

npm notice === Tarball Details ===
npm notice name:          ember-unused-components
npm notice version:       1.0.4
npm notice filename:      ember-unused-components-1.0.4.tgz
npm notice package size:  789.0 kB
npm notice unpacked size: 2.2 MB
npm notice total files:   422
```

### After:
```
➜  ember-unused-components git:(37-smaller-package-size) npm pack --dry-run

npm notice === Tarball Details ===
npm notice name:          ember-unused-components
npm notice version:       1.0.4
npm notice filename:      ember-unused-components-1.0.4.tgz
npm notice package size:  11.7 kB
npm notice unpacked size: 42.1 kB
npm notice total files:   10
```

Closes: https://github.com/vastec/ember-unused-components/issues/37