### PR TITLE
Fix for failOnUnused flag

### DIFF
--- a/index.js
+++ b/index.js
@@ -55,8 +55,9 @@ function main() {
   console.log(colors.dim('[3/3]'), '✔️  Done');
   analyser.logResults(commandOptions.stats, commandOptions.occurrences, config.whitelist);
 
-  if (config.failOnUnused && analyser.unusedComponents.length) {
-    throw new Error(`You have ${analyser.unusedComponents.length} unused components.`);
+  const numUnusedComponents = analyser.unusedComponents().length;
+  if (config.failOnUnused && numUnusedComponents) {
+    throw new Error(`You have ${numUnusedComponents} unused components.`);
   }
 }
 


### PR DESCRIPTION
Despite my `.eucrc.js` setting `failOnUnused: true` the run would always pass. 

It seems that `analyser.unusedComponents` is a function that returns an array, not array itself. 