### PR TITLE
Fix component path resolution for subpath that contains `*components/`

### DIFF
--- a/lib/object-info.js
+++ b/lib/object-info.js
@@ -134,5 +134,5 @@ module.exports = {
  */
 
 function _removeLeadingPath(filepath, subpath) {
-  return filepath.replace(new RegExp(`^.+${subpath}`), '');
+  return filepath.replace(new RegExp(`^.+?${subpath}`), '');
 }


### PR DESCRIPTION
One of our projects has a sub-folder called `web-components` in the `components` folder. This lead to false component path resolution and false positives for unused components as a result. This PR fixes that.