### PR TITLE
Fixed ignored files not being ignored

### DIFF
--- a/lib/analyser.js
+++ b/lib/analyser.js
@@ -356,7 +356,7 @@ module.exports = {
         if (
           (filename.includes('.hbs') || filename.includes('.js') || filename.includes('.ts')) &&
           !filename.includes('-test.js') &&
-          !_isIgnored(filename)
+          !_isIgnored(config, filename)
         ) {
           let type = filename.includes('.hbs') ? 'hbs' : 'js';
           this.componentLookupInFile(filename, type);


### PR DESCRIPTION
The _isIgnored function wasn't being called with the right arguments, which caused the files in config.ignore to not be ignored at all.